### PR TITLE
Switch to managed identity, add FetchNote endpoint, stub out the SearchAsync endpoint

### DIFF
--- a/src/Api/Api.csproj
+++ b/src/Api/Api.csproj
@@ -9,7 +9,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
-		<None Include="local.settings.json" />
 		<PackageReference Include="Azure.AI.DocumentIntelligence" Version="1.0.0-beta.2" />
 		<PackageReference Include="Azure.Search.Documents" Version="11.6.0-beta.1" />
 		<PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
@@ -24,10 +23,9 @@
 		<PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
 		<PackageReference Include="Microsoft.Extensions.Azure" Version="1.7.4" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
-		<PackageReference Include="Microsoft.SemanticKernel" Version="1.15.1" />
 		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.15.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
+		<PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.8" />
 		<PackageReference Include="Azure.Identity" Version="1.12.0" />
 		<PackageReference Include="Tiktoken" Version="2.0.2" />
 	</ItemGroup>

--- a/src/Api/FunctionSettings.cs
+++ b/src/Api/FunctionSettings.cs
@@ -4,16 +4,26 @@
     {
         var envVars = Environment.GetEnvironmentVariables();
 
-        AzureOpenAiKey = string.IsNullOrWhiteSpace(envVars["AzureOpenAiKey"]?.ToString()) ? throw new NullReferenceException("AzureOpenAiKey") : envVars["AzureOpenAiKey"]?.ToString()!;
         AzureOpenAiEmbeddingDeployement = string.IsNullOrWhiteSpace(envVars["AzureOpenAiEmbeddingDeployement"]?.ToString()) ? throw new NullReferenceException("AzureOpenAiEmbeddingDeployement") : envVars["AzureOpenAiEmbeddingDeployement"]?.ToString()!;
         AzureOpenAiEmbeddingModel = string.IsNullOrWhiteSpace(envVars["AzureOpenAiEmbeddingModel"]?.ToString()) ? throw new NullReferenceException("AzureOpenAiEmbeddingModel") : envVars["AzureOpenAiEmbeddingModel"]?.ToString()!;
-        DocIntelApiKey = string.IsNullOrWhiteSpace(envVars["DocIntelApiKey"]?.ToString()) ? throw new NullReferenceException("DocIntelApiKey") : envVars["DocIntelApiKey"]?.ToString()!;
-        SearchIndexName = string.IsNullOrWhiteSpace(envVars["SearchIndexName"]?.ToString()) ? throw new NullReferenceException("SearchIndexName") : envVars["SearchIndexName"]?.ToString()!;
-        SearchKey = string.IsNullOrWhiteSpace(envVars["SearchKey"]?.ToString()) ? throw new NullReferenceException("SearchKey") : envVars["SearchKey"]?.ToString()!; ;
-        SemanticSearchConfigName = string.IsNullOrWhiteSpace(envVars["SemanticSearchConfigName"]?.ToString()) ? throw new NullReferenceException("SemanticSearchConfigName") : envVars["SemanticSearchConfigName"]?.ToString()!;
-        VectorSearchHnswConfigName = string.IsNullOrWhiteSpace(envVars["VectorSearchHnswConfigName"]?.ToString()) ? throw new NullReferenceException("VectorSearchHnswConfigName") : envVars["VectorSearchHnswConfigName"]?.ToString()!;
-        VectorSearchProfileName = string.IsNullOrWhiteSpace(envVars["VectorSearchProfileName"]?.ToString()) ? throw new NullReferenceException("VectorSearchProfileName") : envVars["VectorSearchProfileName"]?.ToString()!;
-        VectorSearchVectorizer = string.IsNullOrWhiteSpace(envVars["VectorSearchVectorizer"]?.ToString()) ? throw new NullReferenceException("VectorSearchVectorizer") : envVars["VectorSearchVectorizer"]?.ToString()!;
+        
+        NoteJsonFileName = string.IsNullOrWhiteSpace(envVars["NoteJsonFileName"]?.ToString()) ? throw new NullReferenceException("NoteJsonFileName") : envVars["NoteJsonFileName"]?.ToString()!;
+
+        var prefix = string.IsNullOrWhiteSpace(envVars["ProjectPrefix"]?.ToString()) ? "damu" : envVars["ProjectPrefix"]?.ToString();
+
+        SearchIndexName = $"-index";
+        SemanticSearchConfigName = $"-semantic-config";
+        VectorSearchHnswConfigName = $"-hnsw-config";
+        VectorSearchProfileName = $"-semantic-profile";
+        VectorSearchVectorizer = $"-search-vectorizer";
+
+#pragma warning disable CS8601 // Possible null reference assignment.
+        // VS doesn't understand that the exception means that there will never be a null reference here
+        BlobStorageConnStr = string.IsNullOrWhiteSpace(envVars["IncomingBlobConnStr"]?.ToString()) ? throw new NullReferenceException("IncomingBlobConnStr") : envVars["IncomingBlobConnStr"]?.ToString()!; ;
+        //var blobStorageEndpoint = string.IsNullOrWhiteSpace(envVars["IncomingBlobConnStr"]?.ToString()) ? throw new NullReferenceException("IncomingBlobConnStr") : envVars["IncomingBlobConnStr"]?.ToString()!; ;
+
+        //if (!Uri.TryCreate(blobStorageEndpoint, UriKind.Absolute, out BlobStorageConnStr))
+        //    throw new ArgumentException($"BlobStorageConnStr {BlobStorageConnStr} is not a valid URI.");
 
         var docIntelEndPoint = string.IsNullOrWhiteSpace(envVars["DocIntelEndPoint"]?.ToString()) ? throw new NullReferenceException("DocIntelEndPoint") : envVars["DocIntelEndPoint"]?.ToString()!; ;
 
@@ -29,6 +39,7 @@
 
         if (!Uri.TryCreate(searchEndpoint, UriKind.Absolute, out SearchEndpoint))
             throw new ArgumentException($"SearchEndpoint {searchEndpoint} is not a valid URI.");
+#pragma warning restore CS8601 // Possible null reference assignment.
 
         ArgumentNullException.ThrowIfNull(envVars["ModelDimensions"]);
 
@@ -47,12 +58,14 @@
             MaxChunkSize = maxChunkSize!;
     }
 
+    public readonly string BlobStorageConnStr;
+    //public readonly Uri BlobStorageConnStr;
+    public readonly string NoteJsonFileName;
+
     public readonly Uri AzureOpenAiEndpoint;
-    public readonly string AzureOpenAiKey;
     public readonly string AzureOpenAiEmbeddingDeployement;
     public readonly string AzureOpenAiEmbeddingModel;
 
-    public readonly string DocIntelApiKey;
     public readonly Uri DocIntelEndPoint;
 
     public int MaxChunkSize = 512;
@@ -60,7 +73,6 @@
 
     public readonly Uri SearchEndpoint;
     public readonly string SearchIndexName;
-    public readonly string SearchKey;
     public readonly string SemanticSearchConfigName;
     public readonly int ModelDimensions;
     public readonly string VectorSearchHnswConfigName;

--- a/src/Api/Functions/FetchNote.cs
+++ b/src/Api/Functions/FetchNote.cs
@@ -1,0 +1,82 @@
+using Api.Models;
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Api.Functions;
+
+public class FetchNote
+{
+    private readonly FunctionSettings _functionSettings;
+    private readonly ILogger<FetchNote> _logger;
+
+    public FetchNote(FunctionSettings functionSettings, ILogger<FetchNote> logger)
+    {
+        _functionSettings = functionSettings;
+        _logger = logger;
+    }
+
+    [Function("FetchNote")]
+    public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "note/{noteId}")] HttpRequest req)
+    {
+        var noteIdStr = req.RouteValues["noteId"];
+
+        if (!int.TryParse(noteIdStr?.ToString(), out var noteId))
+            return new BadRequestObjectResult($"The supplied {nameof(noteId)} of {noteIdStr} is invalid.");
+
+        var blobServiceClient = new BlobServiceClient(_functionSettings.BlobStorageConnStr); //, BlobClientOptions options = default
+
+        var containerClient = blobServiceClient.GetBlobContainerClient("notes");
+
+        var blobClient = containerClient.GetBlobClient(_functionSettings.NoteJsonFileName);
+
+        var blobDownloadResult = await blobClient.DownloadContentAsync();
+
+        if (!blobClient.Exists())
+            throw new Exception($"Unable to find source file {_functionSettings.NoteJsonFileName} in storage.");
+
+        if (blobDownloadResult.Value.Content == null)
+            throw new Exception($"Unable to retrieve valid content from {_functionSettings.NoteJsonFileName} in storage.");
+
+        List<SourceNoteRecord> notes = [];
+
+        var contentStream = blobDownloadResult.Value.Content.ToStream();
+
+        var notes = DeserializeNdJson<SourceNoteRecord>(contentStream) ?? [];
+
+        return notes.ToList().Find(note => note.NoteId == noteId) switch
+        {
+            null => new NotFoundObjectResult($"Note with id {noteId} not found."),
+            var note => new OkObjectResult(note)
+        };
+    }
+
+    private static IEnumerable<T> DeserializeNdJson<T>(Stream stream)
+    {
+        using var textReader = new StreamReader(stream, new UTF8Encoding(false, true), true, 1024, true);
+
+        List<T> results = [];
+
+        while (textReader.Peek() >= 0)
+    {
+            var line = textReader.ReadLine();
+
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            var obj = JsonConvert.DeserializeObject<T>(line);
+
+            if (obj == null)
+                continue;
+
+            results.Add(obj);
+        }
+
+        return results;
+    }
+}

--- a/src/Api/Functions/SearchAsync.cs
+++ b/src/Api/Functions/SearchAsync.cs
@@ -1,96 +1,93 @@
-using Azure.AI.DocumentIntelligence;
+using Api.Models;
 using Azure.AI.OpenAI;
-using Azure.Search.Documents.Indexes;
 using Azure.Search.Documents;
-using Microsoft.AspNetCore.Http;
+using Azure.Search.Documents.Models;
+using Microsoft.AspNetCore.Localization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Extensions.Logging;
 using Microsoft.Azure.Functions.Worker.Http;
-using Azure.Storage.Blobs.Models;
-using Azure.Search.Documents.Models;
-using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace Api.Functions;
 
-public class SearchAsync
+public partial class SearchAsync
 {
-
     private readonly FunctionSettings _functionSettings;
     private readonly ILogger<SearchAsync> _logger;
     private readonly OpenAIClient _openAIClient;
-    private readonly SearchClient _searchClient;                
+    private readonly SearchClient _searchClient;
 
     public SearchAsync(ILogger<SearchAsync> logger, FunctionSettings functionSettings, OpenAIClient openAiClient, SearchClient searchClient)
     {
-        _logger = logger;                        
+        _logger = logger;
         _functionSettings = functionSettings;
         _openAIClient = openAiClient;
         _searchClient = searchClient;
-              
     }
-
-
 
     [Function(nameof(SearchAsync))]
     public async Task<IActionResult> Run([HttpTrigger(AuthorizationLevel.Anonymous, "get", "post")] HttpRequestData req)
     {
-        string query = string.Empty;
-        int k = 3;
-        string filter = string.Empty;
-        
+        var request = (await req.ReadFromJsonAsync<QueryRequest>()) ?? new();
 
-        var searchOptions = new SearchOptions
+        if (string.IsNullOrWhiteSpace(request.Query))
+            return new BadRequestObjectResult("Query is required");
+
+        var options = CreateQuery(request);
+
+        SearchResults<SearchDocument> response = await _searchClient.SearchAsync<SearchDocument>(request.Query, options);
+
+        await foreach (SearchResult<SearchDocument> searchResultDocument in response.GetResultsAsync())
         {
-            Filter = filter,
-            Size = k,
+            Console.WriteLine($"Title: {searchResultDocument.Document["title"]}");
+            Console.WriteLine($"Score: {searchResultDocument.Score}\n");
+            Console.WriteLine($"Content: {searchResultDocument.Document["chunk"]}");
+            if (searchResultDocument.SemanticSearch?.Captions?.Count > 0)
+            {
+                QueryCaptionResult firstCaption = searchResultDocument.SemanticSearch.Captions[0];
+                Console.WriteLine($"First Caption Highlights: {firstCaption.Highlights}");
+                Console.WriteLine($"First Caption Text: {firstCaption.Text}");
+            }
+        }
+
+        // streaming response
+        // tool message with citations first
+
+        var result = new ApiSearchResult
+        {
+
+        };
+
+        return new OkObjectResult(result);
+    }
+
+    private SearchOptions? CreateQuery(QueryRequest request)
+    {
+        return new SearchOptions
+        {
+            Filter = request.Filter,
+            Size = request.KNearestNeighborsCount,
             Select = { "title", "chunk_id", "chunk", },
             IncludeTotalCount = true,
             QueryType = SearchQueryType.Full,
             SemanticSearch = new SemanticSearchOptions
             {
-                SemanticConfigurationName = "my-semantic-config",
+                SemanticConfigurationName = _functionSettings.SemanticSearchConfigName,
                 QueryCaption = new QueryCaption(QueryCaptionType.Extractive),
                 QueryAnswer = new QueryAnswer(QueryAnswerType.Extractive)
             },
             VectorSearch = new()
             {
                 Queries = {
-                new VectorizableTextQuery(text: query)
-                {
-                    KNearestNeighborsCount = k,
-                    Fields = { "vector" },
-                    Exhaustive = true
-                }
-            },
+                new VectorizableTextQuery(text: request.Query)
+                    {
+                        KNearestNeighborsCount = request.KNearestNeighborsCount,
+                        Fields = { "vector" },
+                        Exhaustive = true
+                    }
+                },
 
             }
         };
-
-        SearchResults<SearchDocument> response = await _searchClient.SearchAsync<SearchDocument>(query, searchOptions);
-
-        await foreach (SearchResult<SearchDocument> result in response.GetResultsAsync())
-        {
-            Console.WriteLine($"Title: {result.Document["title"]}");
-            Console.WriteLine($"Score: {result.Score}\n");
-            Console.WriteLine($"Content: {result.Document["chunk"]}");
-            if (result.SemanticSearch?.Captions?.Count > 0)
-            {
-                QueryCaptionResult firstCaption = result.SemanticSearch.Captions[0];
-                Console.WriteLine($"First Caption Highlights: {firstCaption.Highlights}");
-                Console.WriteLine($"First Caption Text: {firstCaption.Text}");
-            }
-        }
-      
-        return new OkObjectResult("Welcome to Azure Functions!");
-
     }
-
-}
-
-public class QueryRequest
-{
-    public string? Query { get; set; }
-    //public float[]? Embedding { get; set; }
-    //public RequestOverrides? Overrides { get; set; }
 }

--- a/src/Api/Models/ApiSearchResult.cs
+++ b/src/Api/Models/ApiSearchResult.cs
@@ -1,0 +1,15 @@
+﻿namespace Api.Functions;
+
+public partial class SearchAsync
+{
+    public class ApiSearchResult
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Model { get; set; } = string.Empty;
+        public DateTimeOffset Created { get; set; } = DateTimeOffset.UtcNow;
+        public object Object { get; set; } = string.Empty;
+        public List<ApiSearchResultChoice> Choices { get; set; } = [];
+        public object HistoryMetadata { get; set; } = string.Empty;
+        public string ApimRequestId { get; set; } = string.Empty;
+    }
+}

--- a/src/Api/Models/ApiSearchResultChoice.cs
+++ b/src/Api/Models/ApiSearchResultChoice.cs
@@ -1,0 +1,9 @@
+﻿namespace Api.Functions;
+
+public partial class SearchAsync
+{
+    public class ApiSearchResultChoice
+    {
+        public List<object> Messages { get; set; } = [];
+    }
+}

--- a/src/Api/Models/QueryRequest.cs
+++ b/src/Api/Models/QueryRequest.cs
@@ -1,0 +1,8 @@
+﻿namespace Api.Models;
+
+public class QueryRequest
+{
+    public string? Query { get; set; }
+    public int? KNearestNeighborsCount { get; set; }
+    public string? Filter { get; set; }
+}

--- a/src/Api/Models/SearchResult.cs
+++ b/src/Api/Models/SearchResult.cs
@@ -1,0 +1,20 @@
+﻿namespace Api.Models;
+
+public class QueryResult
+{
+    public string IndexRecordId { get; set; }
+    public int NoteId { get; set; }
+    public string NoteChunk { get; set; }
+    public string NoteChunkOrder { get; set; }
+    public int CSN { get; set; }
+    public int MRN { get; set; }
+    public string NoteType { get; set; }
+    public string NoteStatus { get; set; }
+    public string AuthorId { get; set; }
+    public string AuthorFirstName { get; set; }
+    public string AuthorLastName { get; set; }
+    public string Department { get; set; }
+    public string Gender { get; set; }
+    public DateTime BirthDate { get; set; }
+}
+

--- a/src/Api/Models/SourceNoteRecord.cs
+++ b/src/Api/Models/SourceNoteRecord.cs
@@ -1,0 +1,57 @@
+﻿namespace Api.Models;
+
+internal class SourceNoteRecord
+{
+    public SourceNoteRecord() { }
+    public SourceNoteRecord(SourceNoteRecord original, string? chunk = null, int? chunkIndex = null)
+    {
+        NoteId = original.NoteId;
+        NoteContent = original.NoteContent;
+        NoteInHtml = original.NoteInHtml;
+        NoteInText = original.NoteInText;
+        NoteChunk = string.IsNullOrWhiteSpace(chunk) ? original.NoteChunk : chunk;
+        NoteChunkOrder = chunkIndex == null ? original.NoteChunkOrder : chunkIndex;
+        NoteChunkVector = original.NoteChunkVector;
+        CSN = original.CSN;
+        MRN = original.MRN;
+        NoteType = original.NoteType;
+        NoteStatus = original.NoteStatus;
+        AuthorId = original.AuthorId;
+        AuthorFirstName = original.AuthorFirstName;
+        AuthorLastName = original.AuthorLastName;
+        Department = original.Department;
+    }
+    public Guid? IndexRecordId { get; set; } = Guid.NewGuid();
+    public long? NoteId { get; set; }
+    public string? NoteContent { get; set; } = string.Empty;
+    public string? NoteInHtml { get; set; } = string.Empty;
+    public string? NoteInText { get; set; } = string.Empty;
+    public string? NoteChunk { get; set; } = string.Empty;
+    public int? NoteChunkOrder { get; set; }
+    public List<float> NoteChunkVector { get; set; } = []; // ?
+    public long? CSN { get; set; }
+    public long? MRN { get; set; }
+    public string? NoteType { get; set; } = string.Empty;
+    public string? NoteStatus { get; set; } = string.Empty;
+    public string? AuthorId { get; set; } = string.Empty;
+    public string? AuthorFirstName { get; set; } = string.Empty;
+    public string? AuthorLastName { get; set; } = string.Empty;
+    public string? Department { get; set; } = string.Empty;
+    public string? Gender { get; set; } = string.Empty;
+    public DateTimeOffset? BirthDate { get; set; }
+
+    public Dictionary<string, object?> ToDictionary()
+    {
+        var result = new Dictionary<string, object?>();
+
+        foreach (var key in GetType().GetProperties())
+        {
+            if (key.Name == "NoteContent" || key.Name == "NoteInHtml" || key.Name == "NoteInText")
+                continue;
+
+            result.Add(key.Name, key.GetValue(this));
+        }
+
+        return result;
+    }
+}

--- a/src/Api/Program.cs
+++ b/src/Api/Program.cs
@@ -1,8 +1,9 @@
-using Azure;
 using Azure.AI.DocumentIntelligence;
 using Azure.AI.OpenAI;
+using Azure.Identity;
 using Azure.Search.Documents;
 using Azure.Search.Documents.Indexes;
+using Azure.Storage.Blobs;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -20,13 +21,13 @@ var host = new HostBuilder()
 
             return new DocumentIntelligenceClient(
                 settings.DocIntelEndPoint,
-                new AzureKeyCredential(settings.DocIntelApiKey));
+                new DefaultAzureCredential());
         });
         services.AddTransient(services =>
         {
             var settings = services.GetRequiredService<FunctionSettings>();
 
-            return new OpenAIClient(settings.AzureOpenAiEndpoint, new AzureKeyCredential(settings.AzureOpenAiKey));
+            return new OpenAIClient(settings.AzureOpenAiEndpoint, new DefaultAzureCredential()); //AzureKeyCredential settings.AzureOpenAiKey
         });
         services.AddTransient(services =>
         {
@@ -35,7 +36,7 @@ var host = new HostBuilder()
             return new SearchClient(
                 settings.SearchEndpoint,
                 settings.SearchIndexName,
-                new AzureKeyCredential(settings.SearchKey)); // todo: move to managed identity
+                new DefaultAzureCredential()); // todo: move to managed identity
         });
         services.AddTransient(services =>
         {
@@ -43,7 +44,7 @@ var host = new HostBuilder()
 
             return new SearchIndexClient(
                 settings.SearchEndpoint,
-                new AzureKeyCredential(settings.SearchKey));
+                 new DefaultAzureCredential());
         });
     })
     .Build();

--- a/src/Api/local.settings.example.json
+++ b/src/Api/local.settings.example.json
@@ -1,21 +1,15 @@
 {
   "IsEncrypted": false,
   "Values": {
-    "AzureOpenAiKey": "",
     "AzureOpenAiEmbeddingDeployedModel": "",
     "AzureOpenAiEndpoint": "",
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "DocIntelApiKey": "",
     "DocIntelEndPoint": "",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "IncomingBlobConnStr": "",
     "ModelDimensions": "",
     "SearchEndpoint": "",
-    "SearchIndexName": "",
-    "SearchKey": "",
-    "SemanticSearchConfigName": "",
-    "VectorSearchHnswConfigName": "",
-    "VectorSearchProfileName": "",
-    "VectorSearchVectorizer": ""
+    "ProjectPrefix": "damu",
+    "NoteJsonFileName": "" // expects ndjson format
   }
 }


### PR DESCRIPTION
This pull request includes significant changes to the `src/Api` directory, with a focus on modifying the project's dependencies, adjusting environment variable usage, and refactoring several functions. The most significant changes are the removal of certain dependencies and environment variables, the addition of new environment variables, the creation of new functions and models, and the modification of existing functions.

Dependency and environment variable changes:

* [`src/Api/Api.csproj`](diffhunk://#diff-3aa7194eea2b139df6a571cea027dab5a6313c9a3f9ed4c988d52b5b0c879c2cL12): Removed the `local.settings.json` file from the project and removed the `Microsoft.SemanticKernel` package. The `Azure.AI.OpenAI` package version was also downgraded. [[1]](diffhunk://#diff-3aa7194eea2b139df6a571cea027dab5a6313c9a3f9ed4c988d52b5b0c879c2cL12) [[2]](diffhunk://#diff-3aa7194eea2b139df6a571cea027dab5a6313c9a3f9ed4c988d52b5b0c879c2cL27-R28)
* [`src/Api/FunctionSettings.cs`](diffhunk://#diff-4935b1cfbb0d616e86526384a0ccf0066fcb9c124128198614d3bb244a37ea5eL7-R26): Several environment variables were removed and new ones were added. The function now uses a prefix and constructs several variables using this prefix. [[1]](diffhunk://#diff-4935b1cfbb0d616e86526384a0ccf0066fcb9c124128198614d3bb244a37ea5eL7-R26) [[2]](diffhunk://#diff-4935b1cfbb0d616e86526384a0ccf0066fcb9c124128198614d3bb244a37ea5eR42) [[3]](diffhunk://#diff-4935b1cfbb0d616e86526384a0ccf0066fcb9c124128198614d3bb244a37ea5eR61-L63)

Function changes:

* [`src/Api/Functions/FetchNote.cs`](diffhunk://#diff-62fcefcbe38c487af70104b2647b8eb747e6a69e435aaf3007e0175b5536fa69R1-R82): A new function was created to fetch notes.
* [`src/Api/Functions/IndexUpserter.cs`](diffhunk://#diff-a80da6ac95b4a82db51c5897f822c7175f38e440737fc36aff8213175a907d24L88): Adjustments were made to the `RunAsync` and `ConvertToSearchDocumentAsync` methods, and the `RecursivelySplitNoteContent` method was simplified. [[1]](diffhunk://#diff-a80da6ac95b4a82db51c5897f822c7175f38e440737fc36aff8213175a907d24L88) [[2]](diffhunk://#diff-a80da6ac95b4a82db51c5897f822c7175f38e440737fc36aff8213175a907d24L104-R107) [[3]](diffhunk://#diff-a80da6ac95b4a82db51c5897f822c7175f38e440737fc36aff8213175a907d24L126-L127) [[4]](diffhunk://#diff-a80da6ac95b4a82db51c5897f822c7175f38e440737fc36aff8213175a907d24L204-L209) [[5]](diffhunk://#diff-a80da6ac95b4a82db51c5897f822c7175f38e440737fc36aff8213175a907d24L245-R238)
* [`src/Api/Functions/SearchAsync.cs`](diffhunk://#diff-29fc4a692bfa05032d3d0815753de4aa6f4d6cedbee8fca73b4ee60b9cd699acL1-L18): The function was refactored to use a new `QueryRequest` model and to return a new `ApiSearchResult` model. [[1]](diffhunk://#diff-29fc4a692bfa05032d3d0815753de4aa6f4d6cedbee8fca73b4ee60b9cd699acL1-L18) [[2]](diffhunk://#diff-29fc4a692bfa05032d3d0815753de4aa6f4d6cedbee8fca73b4ee60b9cd699acL30-L95)

Model changes:

* [`src/Api/Models/ApiSearchResult.cs`](diffhunk://#diff-7fcf53a21d8bc2345d38bb37dc2faa2b906a363479fabaa88a6e674b09b53e10R1-R15): A new model was created to represent the result of an API search.
* [`src/Api/Models/ApiSearchResultChoice.cs`](diffhunk://#diff-08b068294b25777401061d98bd9adff11ea5df57c06ddebb69d15746e4df365cR1-R9): A new model was created to represent a choice in an API search result.
* [`src/Api/Models/QueryRequest.cs`](diffhunk://#diff-b5df675d6bdc6962742d20e02d182cf9f400974901f5fe2b029d786d6311099eR1-R8): A new model was created to represent a query request.
* [`src/Api/Models/SearchResult.cs`](diffhunk://#diff-e138062fdbb9ed7f4f191440049be6c79943b2b3e5806c6d2bbbdc44d84a62b6R1-R20): A new model was created to represent a search result.