### PR TITLE
Pj/search

### DIFF
--- a/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
@@ -34,7 +34,7 @@ public static partial class Endpoints
         [FromBody] ConversationRequest history)
     {
         // do the search here
-        var searchResults = await search.QueryDocumentsAsync(history.Messages[0].Content);
+        var searchResults = await search.QueryDocumentsAsync(history.Messages[^1].Content);
         var toolMsg = new Message
         {
             Id = Guid.NewGuid().ToString(),
@@ -42,10 +42,10 @@ public static partial class Endpoints
             Date = DateTime.UtcNow,
             Content = JsonSerializer.Serialize(searchResults)
         };
+        // add search results to the conversation
         history.Messages.Add(toolMsg);
-        // stuff results into the ChatHistory[]
-        // call completion??
-        // 
+        
+        // return result from LLM
         return Results.Ok(await chat.CompleteChat([.. history.Messages]));
     }
 

--- a/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
@@ -33,6 +33,8 @@ public static partial class Endpoints
         [FromServices] AzureSearchService search,
         [FromBody] ConversationRequest history)
     {
+        // filter out any existing tool messages (search results)
+        history.Messages = history.Messages.Where(m => m.Role != AuthorRole.Tool.ToString().ToLower()).ToList();
         // do the search here
         var searchResults = await search.QueryDocumentsAsync(history.Messages[^1].Content);
         var toolMsg = new Message

--- a/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
@@ -34,7 +34,7 @@ public static partial class Endpoints
         [FromBody] ConversationRequest history)
     {
         // filter out any existing tool messages (search results)
-        history.Messages = history.Messages.Where(m => m.Role != AuthorRole.Tool.ToString().ToLower()).ToList();
+        history.Messages = history.Messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
         // do the search here
         var searchResults = await search.QueryDocumentsAsync(history.Messages[^1].Content);
         var toolMsg = new Message

--- a/src/ChatApp/ChatApp.Server/Services/AzureSearchService.cs
+++ b/src/ChatApp/ChatApp.Server/Services/AzureSearchService.cs
@@ -85,11 +85,11 @@ public class AzureSearchService(SearchClient searchClient)
                 chunkOrderValue is int chunkOrder &&
                 patientFirstNameValue is string patientFirstName &&
                 patientLastNameValue is string patientLastName &&
-                mrnValue is string mrn &&
+                mrnValue is int mrn &&
                 contentValue is string content)
             {
                 content = content.Replace('\r', ' ').Replace('\n', ' ');
-                sb.Add(new SupportingContentRecord(title, content, url, filePath, chunkOrder.ToString(), $"{patientFirstName} {patientLastNameValue}", mrn));
+                sb.Add(new SupportingContentRecord(title, content, url, filePath, chunkOrder.ToString(), $"{patientFirstName} {patientLastNameValue}", mrn.ToString()));
             }
         }
 


### PR DESCRIPTION
This pull request includes several changes to the `ChatApp.Server` project, mainly focusing on refining the chat processing logic and improving the data handling in the `AzureSearchService` and `ChatCompletionService`. The most significant changes involve filtering out existing tool messages before performing a search, using the last user message as the search query, changing the `mrn` value type to `int`, modifying the document content format, and enhancing the chat completion process.

Chat processing logic improvements:

* [`src/ChatApp/ChatApp.Server/Endpoints.Api.cs`](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902R36-R50): In the `MapApiEndpoints` method, the existing tool messages are now filtered out from the conversation history before performing a search. The last user message is used as the search query instead of the first one. The search results are added to the conversation history, and the updated history is used to complete the chat.

Data handling improvements:

* [`src/ChatApp/ChatApp.Server/Services/AzureSearchService.cs`](diffhunk://#diff-bfa99acbc20c7916b07e777f927729f2bd8aeb7ecb4cdaf3e1b5d5c031925773L88-R92): In the `GetResultsAsync` method, the `mrn` value type has been changed from `string` to `int`. The `mrn` value is converted to a string when creating a new `SupportingContentRecord`.
* [`src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfL65-R65): In the `CompleteChat` method, the format of the document contents has been modified to include the patient name and MRN. The sample answer format has also been updated to include newline characters for better readability. [[1]](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfL65-R65) [[2]](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfL80-R82)

Chat completion process enhancement:

* [`src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR93-L117): In the `CompleteChat` method, the assistant response messages are now added to the message history before returning the chat completion. The tool message is no longer explicitly added back to the message list, as it's already included in the updated message history.