### PR TITLE
refactor: Use consistent string comparison strategy

### DIFF
--- a/src/ChatApp/ChatApp.Server/Endpoints.History.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.History.cs
@@ -208,9 +208,9 @@ public static partial class Endpoints
         if (string.IsNullOrWhiteSpace(conversation?.Id))
             return Results.BadRequest("conversation_id is required");
 
-        if (conversation.Messages.Count > 0 && conversation.Messages[^1].Role.Equals(AuthorRole.Assistant.ToString(), StringComparison.InvariantCultureIgnoreCase))
+        if (conversation.Messages.Count > 0 && conversation.Messages[^1].Role.Equals(AuthorRole.Assistant.ToString(), StringComparison.OrdinalIgnoreCase))
         {
-            if (conversation.Messages.Count > 1 && conversation.Messages[^2].Role.Equals(AuthorRole.Tool.ToString(), StringComparison.InvariantCultureIgnoreCase))
+            if (conversation.Messages.Count > 1 && conversation.Messages[^2].Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase))
             {
                 // write the tool message first                
                 await history.CreateMessageAsync(Guid.NewGuid().ToString(), conversation.Id, user.UserPrincipalId, conversation.Messages[^2]);
@@ -253,7 +253,7 @@ public static partial class Endpoints
 
         // Format the incoming message object in the "chat/completions" messages format
         // then write it to the conversation history in cosmos
-        if (conversation.Messages.Count == 0 || !conversation.Messages[^1].Role.Equals(AuthorRole.User.ToString(), StringComparison.InvariantCultureIgnoreCase)) // move role format to enum?
+        if (conversation.Messages.Count == 0 || !conversation.Messages[^1].Role.Equals(AuthorRole.User.ToString(), StringComparison.OrdinalIgnoreCase)) // move role format to enum?
             return Results.BadRequest("No user messages found");
 
         //var result = await chatCompletionService.AlternativeCompleteChat(conversation)

--- a/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
+++ b/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
@@ -57,11 +57,11 @@ public class ChatCompletionService
     public async Task<ChatCompletion> CompleteChat(Message[] messages)
     {
         string documentContents = string.Empty;
-        if (messages.Any(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.InvariantCultureIgnoreCase)))
+        if (messages.Any(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)))
         {
             // parse out the document contents
             var toolContent = JsonSerializer.Deserialize<ToolContentResponse>(
-                messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.InvariantCultureIgnoreCase)).Content);
+                messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).Content);
             documentContents = string.Join("\r", toolContent.Citations.Select(c => $"{c.Title}:{c.Content}:{c.PatientName}:{c.MRN}"));
         }
         else
@@ -85,7 +85,7 @@ public class ChatCompletionService
         var history = new ChatHistory(sysmessage);
 
         // filter out 'tool' messages
-        messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.InvariantCultureIgnoreCase))
+        messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase))
             .ToList()
             .ForEach(m => history.AddUserMessage(m.Content));
         


### PR DESCRIPTION
This pull request primarily focuses on improving the string comparison method in the ChatApp server codebase. The changes involve replacing `StringComparison.InvariantCultureIgnoreCase` with `StringComparison.OrdinalIgnoreCase` for better performance and more accurate results. The changes were made in the `Endpoints.History.cs` and `ChatCompletionService.cs` files.

Here are the most important changes:

Changes in `Endpoints.History.cs`:

* Replaced `StringComparison.InvariantCultureIgnoreCase` with `StringComparison.OrdinalIgnoreCase` in `DeleteAllHistoryAsync` method when comparing the role of the last and second last messages in a conversation. This should provide more accurate comparisons and improve performance.
* Made the same replacement in the same method when checking if the last message in the conversation has a user role.

Changes in `ChatCompletionService.cs`:

* In the `CompleteChat` method, updated the string comparison method when checking if any message has a tool role and when getting the first message with a tool role.
* Also in the `CompleteChat` method, replaced `StringComparison.InvariantCultureIgnoreCase` with `StringComparison.OrdinalIgnoreCase` when filtering out messages with a tool role.

These changes should make the string comparisons more accurate and the application more efficient.