### PR TITLE
refactor: Serialize search results using camel case property naming p…

### DIFF
--- a/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.Api.cs
@@ -37,12 +37,13 @@ public static partial class Endpoints
         history.Messages = history.Messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).ToList();
         // do the search here
         var searchResults = await search.QueryDocumentsAsync(history.Messages[^1].Content);
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         var toolMsg = new Message
         {
             Id = Guid.NewGuid().ToString(),
             Role = AuthorRole.Tool.ToString().ToLower(),
             Date = DateTime.UtcNow,
-            Content = JsonSerializer.Serialize(searchResults)
+            Content = JsonSerializer.Serialize<ToolContentResponse>(searchResults, options)
         };
         // add search results to the conversation
         history.Messages.Add(toolMsg);

--- a/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
+++ b/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
@@ -56,12 +56,13 @@ public class ChatCompletionService
 
     public async Task<ChatCompletion> CompleteChat(Message[] messages)
     {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
         string documentContents = string.Empty;
         if (messages.Any(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)))
         {
             // parse out the document contents
             var toolContent = JsonSerializer.Deserialize<ToolContentResponse>(
-                messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).Content);
+                messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).Content, options);
             documentContents = string.Join("\r", toolContent.Citations.Select(c => $"{c.Title}:{c.Content}:{c.PatientName}:{c.MRN}"));
         }
         else
@@ -76,11 +77,12 @@ public class ChatCompletionService
                 You are an agent helping a medical researcher find medical notes that fit criteria and supplement with additional data, 
                 using the sources available to you. Your response should return a count of notes found and a sample list (maximum 10) of patient's names, corresponding MRNs, and source reference in a table format.
                 If the plugins do not return data based on the question using the provided plugins, respond that you found no information. Do not use general knowledge to respond.                
+                Source references must be in the format [doc1], [doc2], etc.
                 Sample Answer:
                 (2) notes found:\n
                 Patient Name	|	MRN	    |  Citation \n
-                John Johnson 	|	1234567 |  [reference1.json] \n
-                Peter Peterson	| 	7654321 |  [reference2.json]
+                John Johnson 	|	1234567 |  [doc1] \n
+                Peter Peterson	| 	7654321 |  [doc2]
                 """;
         var history = new ChatHistory(sysmessage);
 


### PR DESCRIPTION
…olicy
This pull request includes changes in the `ChatApp.Server` project to improve the serialization of JSON objects and to update the format of source references in the chat completion service. The changes are mainly focused on two files: `Endpoints.Api.cs` and `ChatCompletionService.cs`.

JSON Serialization Improvements:

* [`src/ChatApp/ChatApp.Server/Endpoints.Api.cs`](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902R40-R46): Updated the `MapApiEndpoints` method to use a `JsonSerializerOptions` object with `PropertyNamingPolicy` set to `JsonNamingPolicy.CamelCase`. This change affects the serialization of `searchResults` into `toolMsg.Content`.

* [`src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR59-R65): Similar to the above change, a `JsonSerializerOptions` object is used in the `CompleteChat` method to deserialize `ToolContentResponse` from `messages`.

Source Reference Format Update:

* [`src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR80-R85): The source references format in the chat completion service was updated from `[referenceX.json]` to `[docX]`. This change affects the sample answer provided in the `CompleteChat` method.