### PR TITLE
Mjschanne/export

### DIFF
--- a/src/ChatApp/ChatApp.Server/ChatApp.Server.csproj
+++ b/src/ChatApp/ChatApp.Server/ChatApp.Server.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.41.0" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.15.0" />
     <PackageReference Include="Microsoft.SemanticKernel.Plugins.Core" Version="1.15.0-alpha" />
+    <PackageReference Include="Microsoft.SemanticKernel.Yaml" Version="1.16.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/src/ChatApp/ChatApp.Server/Endpoints.History.cs
+++ b/src/ChatApp/ChatApp.Server/Endpoints.History.cs
@@ -243,7 +243,8 @@ public static partial class Endpoints
         if (conversation == null)
             return Results.BadRequest();
 
-        if (string.IsNullOrWhiteSpace(conversation.Id))
+        // if title is empty that means it is a new conversation
+        if (string.IsNullOrWhiteSpace(conversation.Title))
         {
             var title = await chatCompletionService.GenerateTitleAsync(conversation.Messages);
 

--- a/src/ChatApp/ChatApp.Server/Models/Message.cs
+++ b/src/ChatApp/ChatApp.Server/Models/Message.cs
@@ -14,9 +14,18 @@ public class Message
     {
         // todo: is there anything else we can do here, maybe with date?
         // or author? https://learn.microsoft.com/en-us/dotnet/api/microsoft.semantickernel.chatmessagecontent?view=semantic-kernel-dotnet
+        var role = Role.ToLower() switch
+        {
+            "user" => AuthorRole.User,
+            "assistant" => AuthorRole.Assistant,
+            "tool" => AuthorRole.Tool,
+            "system" => AuthorRole.System,
+            _ => throw new ArgumentException("Invalid role", nameof(Role))
+        };
+
         return new ChatMessageContent
         {
-            Role = Enum.Parse<AuthorRole>(Role),
+            Role = role,
             Content = Content,
         };
     }

--- a/src/ChatApp/ChatApp.Server/Plugins/TextPlugin/SummarizeConversation.yaml
+++ b/src/ChatApp/ChatApp.Server/Plugins/TextPlugin/SummarizeConversation.yaml
@@ -1,0 +1,19 @@
+name: SummarizeConversation
+template: |
+        {{$history}}
+        ---
+        Summarize this text. One to three words maximum length. 
+        Plain text only. No punctuation, markup or tags.
+template_format: semantic-kernel
+description: A function generates a short summary name for the chat session.
+input_variables:
+  - name: history
+    description: The conversation history from chat.
+    is_required: true
+output_variable:
+  description: a short summary.
+execution_settings:
+  default:
+    temperature: 0.2
+    max_tokens: 1000
+    top_p: 0.7

--- a/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
+++ b/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
@@ -12,6 +12,7 @@ public class ChatCompletionService
 {
     private readonly Kernel _kernel;
     private readonly PromptExecutionSettings _promptSettings;
+    private readonly string _promptDirectory;
 
     public ChatCompletionService(IConfiguration config, AzureSearchService searchService)
     {
@@ -37,6 +38,11 @@ public class ChatCompletionService
             builder = builder.AddAzureOpenAITextEmbeddingGeneration(embeddingModelName, endpoint, defaultAzureCreds);
             builder = builder.AddAzureOpenAIChatCompletion(deployedModelName, endpoint, defaultAzureCreds);
         }
+
+        _promptDirectory = Path.Combine(Directory.GetCurrentDirectory(),"Plugins");
+
+        builder.Plugins.AddFromPromptDirectory(_promptDirectory);
+
         //builder.Plugins.AddFromObject(searchService, "SearchNotes");
         _kernel = builder.Build();
     }
@@ -88,20 +94,20 @@ public class ChatCompletionService
         messages.Where(m => !m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase))
             .ToList()
             .ForEach(m => history.AddUserMessage(m.Content));
-        
+
         var response = await _kernel.GetRequiredService<IChatCompletionService>().GetChatMessageContentAsync(history, _promptSettings, _kernel);
         // add assistant response message to history and return chatcompletion
 
         // append response messages to messages array
         var responseMessages = messages.ToList();
+
         response.Items.ToList().ForEach(item => responseMessages.Add(new Message
         {
             Id = Guid.NewGuid().ToString(),
             Role = AuthorRole.Assistant.ToString().ToLower(),
             Content = item.ToString()!,
             Date = DateTime.UtcNow
-
-        }));        
+        }));
 
         var result = new ChatCompletion
         {
@@ -112,34 +118,6 @@ public class ChatCompletionService
             Choices = [new() {
                 Messages = [.. responseMessages]
             }]
-        };        
-
-        return result;
-    }
-
-
-
-    public async Task<ChatCompletion> AlternativeCompleteChat(IEnumerable<Message> messages)
-    {
-        var history = new ChatHistory(messages.Select(m => m.ToChatMessageContent()).ToList());
-
-        var response = await _kernel.GetRequiredService<IChatCompletionService>().GetChatMessageContentAsync(history, _promptSettings);
-
-        var result = new ChatCompletion
-        {
-            Id = Guid.NewGuid().ToString(),
-            ApimRequestId = Guid.NewGuid().ToString(),
-            Model = response.ModelId!,
-            Created = DateTime.UtcNow,
-            Choices = [new() {
-                Messages = response.Items.Select(item => new Message
-                {
-                    Id = Guid.NewGuid().ToString(),
-                    Role = AuthorRole.Assistant.ToString(),
-                    Content = item.ToString()!,
-                    Date = DateTime.UtcNow
-                }).ToList()
-            }]
         };
 
         return result;
@@ -147,12 +125,19 @@ public class ChatCompletionService
 
     public async Task<string> GenerateTitleAsync(List<Message> messages)
     {
-        Console.WriteLine(messages);
-        // "Summarize the conversation so far into a 4-word or less title. Do not use any quotation marks or punctuation. Do not include any other commentary or description."
-        
-        // is there an OOB summary plugin or do we right our own against a history...?
-        await Task.Delay(0);
-        throw new NotImplementedException();
+        // Create a conversation string from the messages
+        string conversationText = string.Join(" ", messages.Select(m => m.Role + " " + m.Content));
+
+        // Load prompt yaml
+        var promptYaml = File.ReadAllText(Path.Combine(_promptDirectory, "TextPlugin", "SummarizeConversation.yaml"));
+        var function = _kernel.CreateFunctionFromPromptYaml(promptYaml);
+
+        // Invoke the function against the conversation text
+        var result = await _kernel.InvokeAsync(function, new() { { "history", conversationText } });
+
+        string completion = result.ToString()!;
+
+        return completion;
     }
 }
 

--- a/src/IndexOrchestration/Program.cs
+++ b/src/IndexOrchestration/Program.cs
@@ -1,5 +1,4 @@
 using Api.Models;
-using API;
 using Azure;
 using Azure.AI.DocumentIntelligence;
 using Azure.AI.OpenAI;


### PR DESCRIPTION
This pull request includes changes to the `ChatApp.Server` project to improve the chat completion service, update the project's dependencies, and refactor some of the existing code. The main changes include adding a new package reference, updating the condition for generating a conversation title, refactoring the `ToChatMessageContent` method, adding a new YAML file, and modifying the `ChatCompletionService` class.

Changes to project dependencies:

* [`src/ChatApp/ChatApp.Server/ChatApp.Server.csproj`](diffhunk://#diff-80d6711d9b99039c3aadd908d70820ca9bf7cfe17157e82b46dc305d09f90fb5R24): Added a new package reference to `Microsoft.SemanticKernel.Yaml` version `1.16.0`.

Changes to conversation title generation:

* [`src/ChatApp/ChatApp.Server/Endpoints.History.cs`](diffhunk://#diff-38f8fbc54f31305b3556909b802f5695745e792a53e7764431f7e1d832891739L246-R247): Updated the condition for generating a conversation title. The title is now generated if the conversation's title is empty, which indicates that it's a new conversation.

Refactoring:

* [`src/ChatApp/ChatApp.Server/Models/Message.cs`](diffhunk://#diff-a4bfc3891cb7b4f168b46922aaa4ae97ac79972c423a1fba48784ebae1b1b591R17-R28): Refactored the `ToChatMessageContent` method to use a switch expression for determining the `AuthorRole` based on the `Role` property.

Addition of new YAML file:

* [`src/ChatApp/ChatApp.Server/Plugins/TextPlugin/SummarizeConversation.yaml`](diffhunk://#diff-3181583f6def7b5d7741850dafe75a105f5605a641f5849bab969b206a274605R1-R19): Added a new YAML file that defines a function for generating a short summary of the chat session.

Changes to `ChatCompletionService` class:

* [`src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR15): Modified the `ChatCompletionService` class to include a new `_promptDirectory` field, load plugins from the prompt directory, and refactor the `CompleteChat` and `GenerateTitleAsync` methods. [[1]](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR15) [[2]](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR41-R45) [[3]](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfR103-L103) [[4]](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfL120-R140)