### PR TITLE
refactor: Update SupportingContentRecord in ResponseChoice.cs and Azu…

### DIFF
--- a/src/ChatApp/ChatApp.Server/Models/ResponseChoice.cs
+++ b/src/ChatApp/ChatApp.Server/Models/ResponseChoice.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace ChatApp.Server.Models;
 
-public record SupportingContentRecord(string Title, string Content, string Url, string Filepath, string ChunkId, string PatientName, string MRN);
+public record SupportingContentRecord(string Title, string Content, string Url, string Filepath, string ChunkId, string AdditionalContent);
 
 public record ToolContentResponse(List<SupportingContentRecord> Citations, List<string> Intent);
 

--- a/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
+++ b/src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs
@@ -69,7 +69,7 @@ public class ChatCompletionService
             // parse out the document contents
             var toolContent = JsonSerializer.Deserialize<ToolContentResponse>(
                 messages.First(m => m.Role.Equals(AuthorRole.Tool.ToString(), StringComparison.OrdinalIgnoreCase)).Content, options);
-            documentContents = string.Join("\r", toolContent.Citations.Select(c => $"{c.Title}:{c.Content}:{c.PatientName}:{c.MRN}"));
+            documentContents = string.Join("\r", toolContent.Citations.Select(c => $"{c.Title}:{c.Content}:{c.AdditionalContent}"));
         }
         else
         {


### PR DESCRIPTION
…reSearchService.cs

This pull request primarily focuses on refactoring the `SupportingContentRecord` model and related changes in the `AzureSearchService` and `ChatCompletionService` classes. The changes are aimed at improving the flexibility of the `SupportingContentRecord` model by replacing specific patient-related fields with a more generic `AdditionalContent` field. This allows for a more dynamic and flexible handling of data.

Here are the key changes:

Changes to the `SupportingContentRecord` model:

* [`src/ChatApp/ChatApp.Server/Models/ResponseChoice.cs`](diffhunk://#diff-88dec0fc6a45e5e361456a48788f7dffd11aa0de62eb663452d049900e8ad61bL7-R7): The `SupportingContentRecord` model was updated. The `PatientName` and `MRN` fields were replaced with an `AdditionalContent` field. This change is aimed at making the model more flexible by allowing it to handle a wider variety of data.

Changes to the `AzureSearchService` class:

* [`src/ChatApp/ChatApp.Server/Services/AzureSearchService.cs`](diffhunk://#diff-bfa99acbc20c7916b07e777f927729f2bd8aeb7ecb4cdaf3e1b5d5c031925773L1-R25): Unnecessary namespace imports were removed, and the `System.Text.Json` namespace was added. A new private field `_indexContentFields` was introduced, which contains an array of string field names. This array is used to dynamically handle different types of index content.
* [`src/ChatApp/ChatApp.Server/Services/AzureSearchService.cs`](diffhunk://#diff-bfa99acbc20c7916b07e777f927729f2bd8aeb7ecb4cdaf3e1b5d5c031925773L66-L68): The `QueryDocumentsAsync` method was updated. The handling of document fields `PatientFirstName`, `PatientLastName`, and `MRN` was removed. Instead, all fields specified in `_indexContentFields` are now included in the `AdditionalContent` field of the `SupportingContentRecord` model. [[1]](diffhunk://#diff-bfa99acbc20c7916b07e777f927729f2bd8aeb7ecb4cdaf3e1b5d5c031925773L66-L68) [[2]](diffhunk://#diff-bfa99acbc20c7916b07e777f927729f2bd8aeb7ecb4cdaf3e1b5d5c031925773R91-R101)

Changes to the `ChatCompletionService` class:

* [`src/ChatApp/ChatApp.Server/Services/ChatCompletionService.cs`](diffhunk://#diff-7f4bc058aa1a8e4a2b915bd9d18cc714b3cf57e5883832e591ceeed3a641bdbfL72-R72): The `CompleteChat` method was updated. The way document contents are parsed from `toolContent.Citations` was changed to reflect the updates to the `SupportingContentRecord` model. Now, `AdditionalContent` is used instead of `PatientName` and `MRN`.