### PR TITLE
refactor: Update AzureAdOptions and FrontendSettings initialization

### DIFF
--- a/src/ChatApp/ChatApp.Server/ChatAppExtensions.cs
+++ b/src/ChatApp/ChatApp.Server/ChatAppExtensions.cs
@@ -27,7 +27,11 @@ internal static class ChatAppExtensions
 
     internal static void AddChatAppServices(this IServiceCollection services, IConfiguration config)
     {
-        var defaultAzureCreds = new DefaultAzureCredential();
+        var azureAdOptions = config.GetSection(nameof(AzureAdOptions)).Get<AzureAdOptions>();
+        var frontendSettings = config.GetSection(nameof(FrontendSettings)).Get<FrontendSettings>();
+
+        var defaultAzureCreds = string.IsNullOrEmpty(azureAdOptions.TenantId) ? new DefaultAzureCredential()
+            : new DefaultAzureCredential(new DefaultAzureCredentialOptions { TenantId = azureAdOptions.TenantId });
 
         services.AddSingleton<ChatCompletionService>();
 
@@ -61,7 +65,7 @@ internal static class ChatAppExtensions
 
         services.AddSingleton<AzureSearchService>();
 
-        var isChatEnabled = bool.TryParse(config["ENABLE_CHAT_HISTORY"], out var result) && result;
+        var isChatEnabled = frontendSettings?.HistoryEnabled ?? false;
 
         if (isChatEnabled)
         {

--- a/src/ChatApp/ChatApp.Server/Models/FrontendSettings.cs
+++ b/src/ChatApp/ChatApp.Server/Models/FrontendSettings.cs
@@ -1,36 +1,35 @@
-using System.Text.Json.Serialization;
 
 namespace ChatApp.Server.Models;
 
 public class FrontendSettings
 {
-    [JsonPropertyName("auth_enabled")]
+    [ConfigurationKeyName("auth_enabled")]
     public bool AuthEnabled { get; set; } = false;
 
-    [JsonPropertyName("feedback_enabled")]
+    [ConfigurationKeyName("feedback_enabled")]
     public bool FeedbackEnabled { get; set; } = false;
 
-    [JsonPropertyName("ui")]
+    [ConfigurationKeyName("ui")]
     public UiSettings Ui { get; set; } = new();
 
-    [JsonPropertyName("sanitize_answer")]
+    [ConfigurationKeyName("sanitize_answer")]
     public bool SanitizeAnswer { get; set; } = false;
 
-    [JsonPropertyName("history_enabled")]
+    [ConfigurationKeyName("history_enabled")]
     public bool HistoryEnabled { get; set; } = false;
 }
 
 public class UiSettings
 {
-    [JsonPropertyName("title")]
+    [ConfigurationKeyName("title")]
     public string Title { get; set; } = "Damu";
 
-    [JsonPropertyName("chat_title")]
+    [ConfigurationKeyName("chat_title")]
     public string ChatTitle { get; set; } = "Start chatting";
 
-    [JsonPropertyName("chat_description")]
+    [ConfigurationKeyName("chat_description")]
     public string ChatDescription { get; set; } = "This chatbot is configured to answer your questions";
 
-    [JsonPropertyName("show_share_button")]
+    [ConfigurationKeyName("show_share_button")]
     public bool ShowShareButton { get; set; } = true;
 }


### PR DESCRIPTION
This pull request primarily focuses on enhancing the configuration and routing of the ChatApp Server. The changes include the addition of `AzureAdOptions` and `FrontendSettings` in the `AddChatAppServices` method, modification of the `isChatEnabled` variable, refactoring of the `MapApiEndpoints` method, and renaming of JSON property names in the `FrontendSettings` class.

Configuration changes:

* [`src/ChatApp/ChatApp.Server/ChatAppExtensions.cs`](diffhunk://#diff-a4a53c70980551b6846cb0cc64cfda9d9aba84be805fe05aa59e2e4b7d809456L30-R34): `AzureAdOptions` and `FrontendSettings` were added to the `AddChatAppServices` method to enhance the configuration. This includes a conditional check for `TenantId` in `AzureAdOptions` and a change in the way `isChatEnabled` is determined, now using `frontendSettings?.HistoryEnabled` instead of a boolean parse from the configuration. [[1]](diffhunk://#diff-a4a53c70980551b6846cb0cc64cfda9d9aba84be805fe05aa59e2e4b7d809456L30-R34) [[2]](diffhunk://#diff-a4a53c70980551b6846cb0cc64cfda9d9aba84be805fe05aa59e2e4b7d809456L64-R68)

Routing changes:

* [`src/ChatApp/ChatApp.Server/Endpoints.Api.cs`](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902L15-R20): The `MapApiEndpoints` method was refactored to include `GetFrontendSettings` and to change `PostConversation` and `PostSearch` to their asynchronous counterparts. Additionally, a new method `GetFrontendSettings` was added to handle the `/frontend_settings` endpoint, which serializes the `FrontendSettings` object using snake case lower naming policy. [[1]](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902L15-R20) [[2]](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902L32-R41) [[3]](diffhunk://#diff-6cdaa69085f8d0cd0db2369667e1d218e2da51da0c61e6c81cd7bea2e996f902L56-R65)

Model changes:

* [`src/ChatApp/ChatApp.Server/Models/FrontendSettings.cs`](diffhunk://#diff-5330cb4440bc54fc62b777036d39bf5929a7a887bedafc5af0aa4baf7accbf61L1-R33): The JSON property names of the `FrontendSettings` class were renamed to match the configuration key names using the `ConfigurationKeyName` attribute.