### PR TITLE
Pj/provisioning

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -8,7 +8,7 @@ services:
     project: ./src/ChatApp/ChatApp.Server
     language: dotnet
     host: appservice
-  index-function:
+  indexer:
     project: ./src/IndexOrchestration
     language: dotnet
     host: function

--- a/infra/app/backend.bicep
+++ b/infra/app/backend.bicep
@@ -7,6 +7,7 @@ param authClientId string
 param authClientSecret string
 param authIssuerUri string
 param storageAccountName string
+param serviceName string = 'backend'
 param appSettings object = {}
 
 resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
@@ -14,7 +15,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
 }
 
 module appServicePlan '../core/host/appserviceplan.bicep' = {
-  name: 'appserviceplan'
+  name: 'appserviceplan-${serviceName}'
   params: {
     name: appServicePlanName
     location: location
@@ -28,11 +29,11 @@ module appServicePlan '../core/host/appserviceplan.bicep' = {
 }
 
 module backend '../core/host/appservice.bicep' = {
-  name: 'web'
+  name: 'web-${serviceName}'
   params: {
     name: appServiceName
     location: location
-    tags: union(tags, { 'azd-service-name': 'backend' })
+    tags: union(tags, { 'azd-service-name': serviceName })
     appServicePlanId: appServicePlan.outputs.id
     runtimeName: 'dotnet'
     runtimeVersion: '8'

--- a/infra/app/backend.bicep
+++ b/infra/app/backend.bicep
@@ -43,7 +43,7 @@ module backend '../core/host/appservice.bicep' = {
     authClientId: authClientId
     authIssuerUri: authIssuerUri
     appSettings: union(appSettings, {
-      'StorageOptions:BlobStorageConnectionString': 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value}'
+      StorageOptions__BlobStorageConnectionString: 'DefaultEndpointsProtocol=https;AccountName=${storage.name};AccountKey=${storage.listKeys().keys[0].value}'
     })
   }
 }

--- a/infra/app/function.bicep
+++ b/infra/app/function.bicep
@@ -7,7 +7,7 @@ param applicationInsightsName string = ''
 param appServicePlanName string
 @secure()
 param appSettings object = {}
-param serviceName string = 'index-function'
+param serviceName string = 'indexer'
 param storageAccountName string
 param useManagedIdentity bool
 
@@ -16,7 +16,7 @@ resource storage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
 }
 
 module appServicePlanFunction '../core/host/appserviceplan.bicep' = {
-  name: 'appserviceplanApi'
+  name: 'appserviceplan-${serviceName}'
   params: {
     name: appServicePlanName
     location: location
@@ -28,7 +28,7 @@ module appServicePlanFunction '../core/host/appserviceplan.bicep' = {
   }
 }
 
-module function '../core/host/functions.bicep' = {
+module functionIndexer '../core/host/functions.bicep' = {
   name: '${serviceName}-function'
   params: {
     name: name
@@ -49,6 +49,6 @@ module function '../core/host/functions.bicep' = {
   }
 }
 
-output SERVICE_FUNCTION_IDENTITY_PRINCIPAL_ID string = function.outputs.identityPrincipalId
-output SERVICE_FUNCTION_NAME string = function.outputs.name
-output SERVICE_FUNCTION_URI string = function.outputs.uri
+output SERVICE_FUNCTION_IDENTITY_PRINCIPAL_ID string = functionIndexer.outputs.identityPrincipalId
+output SERVICE_FUNCTION_NAME string = functionIndexer.outputs.name
+output SERVICE_FUNCTION_URI string = functionIndexer.outputs.uri

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -164,27 +164,27 @@ module backend 'app/backend.bicep' = {
     authIssuerUri: authIssuerUri
     appSettings: {
       // frontend settings
-      'FrontendSettings:auth_enabled': 'false'
-      'FrontendSettings:feedback_enabled': 'false'
-      'FrontendSettings:ui:title': 'Damu'
-      'FrontendSettings:ui:chat_description': 'This chatbot is configured to answer your questions.'
-      'FrontendSettings:ui:show_share_button': true
-      'FrontendSettings:sanitize_answer': false
-      'FrontendSettings:history_enabled': isHistoryEnabled
+      FrontendSettings__auth_enabled: 'false'
+      FrontendSettings__feedback_enabled: 'false'
+      FrontendSettings__ui__title: 'Damu'
+      FrontendSettings__ui__chat_description: 'This chatbot is configured to answer your questions.'
+      FrontendSettings__ui__show_share_button: true
+      FrontendSettings__sanitize_answer: false
+      FrontendSettings__history_enabled: isHistoryEnabled
       // search
-      'AISearchOptions:Endpoint': searchService.outputs.endpoint
-      'AISearchOptions:ApiKey': ''
-      'AISearchOptions:IndexName': searchIndexName
-      'AISearchOptions:SemanticConfigurationName': searchSemanticSearchConfig
+      AISearchOptions__Endpoint: searchService.outputs.endpoint
+      AISearchOptions__ApiKey: ''
+      AISearchOptions__IndexName: searchIndexName
+      AISearchOptions__SemanticConfigurationName: searchSemanticSearchConfig
       // openai
-      'OpenAIOptions:Endpoint': openAi.outputs.endpoint
-      'OpenAIOptions:ApiKey': ''
-      'OpenAIOptions:ChatDeployment': chatDeploymentName
-      'OpenAIOptions:EmbeddingDeployment': embeddingDeploymentName
+      OpenAIOptions__Endpoint: openAi.outputs.endpoint
+      OpenAIOptions__ApiKey: ''
+      OpenAIOptions__ChatDeployment: chatDeploymentName
+      OpenAIOptions__EmbeddingDeployment: embeddingDeploymentName
       // storage
-      'StorageOptions:BlobStorageEndpoint': storage.outputs.primaryEndpoints.blob
-      'StorageOptions:BlobStorageConnectionString': ''
-      'StorageOptions:BlobStorageContainerName': storageContainerName      
+      StorageOptions__BlobStorageEndpoint: storage.outputs.primaryEndpoints.blob
+      StorageOptions__BlobStorageConnectionString: ''
+      StorageOptions__BlobStorageContainerName: storageContainerName
     }
   }
 }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -156,7 +156,7 @@ module backend 'app/backend.bicep' = {
   params: {
     location: location
     tags: union(tags, { 'azd-service-name': 'backend' })
-    appServicePlanName: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}${resourceToken}'
+    appServicePlanName: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}backend-${resourceToken}'
     appServiceName: appServiceName
     storageAccountName: storage.outputs.name
     authClientSecret: authClientSecret
@@ -190,15 +190,16 @@ module backend 'app/backend.bicep' = {
 }
 
 // Index Orchestrator
+var functionAppServiceName = !empty(functionServiceName) ? functionServiceName : '${abbrs.webSitesFunctions}function-${resourceToken}'
 module function './app/function.bicep' = {
   name: 'function'
   scope: resourceGroup
   params: {
-    name: !empty(functionServiceName) ? functionServiceName : '${abbrs.webSitesFunctions}function-${resourceToken}'
+    name: functionAppServiceName
     location: location
     tags: tags
     applicationInsightsName: monitoring.outputs.applicationInsightsName
-    appServicePlanName: !empty(functionAppServicePlanName) ? functionAppServicePlanName : '${abbrs.webServerFarms}${resourceToken}'
+    appServicePlanName: !empty(functionAppServicePlanName) ? functionAppServicePlanName : '${abbrs.webServerFarms}function-${resourceToken}'
     storageAccountName: storage.outputs.name
     useManagedIdentity: true
     appSettings: {
@@ -207,7 +208,6 @@ module function './app/function.bicep' = {
       AzureOpenAiEndpoint: openAi.outputs.endpoint
       DocIntelEndPoint: formRecognizer.outputs.endpoint
       FUNCTIONS_WORKER_RUNTIME: 'dotnet-isolated'
-      IncomingBlobConnStr: ''
       ModelDimensions: embeddingVectorDimension
       ProjectPrefix: environmentName
       SearchEndpoint: searchService.outputs.endpoint


### PR DESCRIPTION
This pull request primarily involves changes to the configuration and deployment infrastructure of the application. The changes mostly revolve around renaming services, modifying parameters, and altering the structure of the application settings. The most significant changes are:

Renaming of services:
* The `index-function` service in `azure.yaml` has been renamed to `indexer`.
* The `infra/app/backend.bicep` and `infra/app/function.bicep` files have had their `serviceName` parameter changed from `backend` and `index-function` to `backend` and `indexer` respectively [[1]](diffhunk://#diff-7d811948fcd2820e60d5618ba1f7262bdf20b65b0971267913211a10b94de686R10-R18) [[2]](diffhunk://#diff-b75c12b2dab56bceb24980d55cb54f938ae2b4c66926dcf48e9625f13bd3042aL10-R10).

Modification of parameters:
* The `infra/main.bicep` file has had its `chatDeploymentName` parameter changed from `gpt-4o` to `chat`, and new parameters `chatModelVersion` and `embeddingModelVersion` have been added.

Changes to application settings:
* In `infra/app/backend.bicep` and `infra/main.bicep`, the format of the application settings keys has been changed from using colons (:) to double underscores (__) [[1]](diffhunk://#diff-7d811948fcd2820e60d5618ba1f7262bdf20b65b0971267913211a10b94de686L45-R46) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L173-R202).
* The `infra/main.bicep` file has had the `IncomingBlobConnStr` setting removed.

Other significant changes include:
* The removal of the `appServicePlan` module in `infra/main.bicep`.
* The `principalType` for `storageRoleBackend` and `storageRoleFunctionApp` in `infra/main.bicep` has been changed from `User` to `ServicePrincipal` [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L369-R355) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L379-R365).
* Several CosmosDB-related outputs have been removed from `infra/main.bicep`.