### PR TITLE
Pj/provisioning

### DIFF
--- a/infra/app/backend.bicep
+++ b/infra/app/backend.bicep
@@ -24,7 +24,6 @@ module appServicePlan '../core/host/appserviceplan.bicep' = {
       name: 'B1'
       capacity: 1
     }
-    kind: 'windows'
   }
 }
 
@@ -35,8 +34,6 @@ module backend '../core/host/appservice.bicep' = {
     location: location
     tags: union(tags, { 'azd-service-name': serviceName })
     appServicePlanId: appServicePlan.outputs.id
-    runtimeName: 'dotnet'
-    runtimeVersion: '8'
     scmDoBuildDuringDeployment: true
     managedIdentity: true
     authClientSecret: authClientSecret

--- a/infra/core/host/appservice.bicep
+++ b/infra/core/host/appservice.bicep
@@ -8,16 +8,8 @@ param appServicePlanId string
 param keyVaultName string = ''
 param managedIdentity bool = !empty(keyVaultName)
 
-// Runtime Properties
-@allowed([
-  'dotnet', 'dotnetcore', 'dotnet-isolated', 'node', 'python', 'java', 'powershell', 'custom'
-])
-param runtimeName string
-param runtimeNameAndVersion string = '${runtimeName}|${runtimeVersion}'
-param runtimeVersion string
-
 // Microsoft.Web/sites Properties
-param kind string = 'app,linux'
+param kind string = ''
 
 // Microsoft.Web/sites/config
 param allowedOrigins array = []
@@ -31,7 +23,6 @@ param authIssuerUri string = ''
 param clientAffinityEnabled bool = false
 param enableOryxBuild bool = contains(kind, 'linux')
 param functionAppScaleLimit int = -1
-param linuxFxVersion string = runtimeNameAndVersion
 param minimumElasticInstanceCount int = -1
 param numberOfWorkers int = -1
 param scmDoBuildDuringDeployment bool = false
@@ -47,7 +38,6 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
   properties: {
     serverFarmId: appServicePlanId
     siteConfig: {
-      linuxFxVersion: linuxFxVersion
       alwaysOn: alwaysOn
       ftpsState: ftpsState
       appCommandLine: appCommandLine

--- a/infra/core/host/appserviceplan.bicep
+++ b/infra/core/host/appserviceplan.bicep
@@ -3,7 +3,6 @@ param location string = resourceGroup().location
 param tags object = {}
 
 param kind string = ''
-param reserved bool = true
 param sku object
 
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
@@ -11,10 +10,7 @@ resource appServicePlan 'Microsoft.Web/serverfarms@2022-03-01' = {
   location: location
   tags: tags
   sku: sku
-  kind: kind
-  properties: {
-    reserved: reserved
-  }
+  kind: kind  
 }
 
 output id string = appServicePlan.id

--- a/infra/core/host/functions.bicep
+++ b/infra/core/host/functions.bicep
@@ -35,7 +35,6 @@ param appSettings object = {}
 param clientAffinityEnabled bool = false
 param enableOryxBuild bool = contains(kind, 'linux')
 param functionAppScaleLimit int = -1
-param linuxFxVersion string = runtimeNameAndVersion
 param minimumElasticInstanceCount int = -1
 param numberOfWorkers int = -1
 param scmDoBuildDuringDeployment bool = true
@@ -63,12 +62,8 @@ module functions 'appservice.bicep' = {
     functionAppScaleLimit: functionAppScaleLimit
     healthCheckPath: healthCheckPath
     kind: kind
-    linuxFxVersion: linuxFxVersion
     minimumElasticInstanceCount: minimumElasticInstanceCount
     numberOfWorkers: numberOfWorkers
-    runtimeName: runtimeName
-    runtimeVersion: runtimeVersion
-    runtimeNameAndVersion: runtimeNameAndVersion
     scmDoBuildDuringDeployment: scmDoBuildDuringDeployment
     use32BitWorkerProcess: use32BitWorkerProcess
     managedIdentity: managedIdentity

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -155,7 +155,7 @@ module backend 'app/backend.bicep' = {
   scope: resourceGroup
   params: {
     location: location
-    tags: union(tags, { 'azd-service-name': 'backend' })
+    tags: tags
     appServicePlanName: !empty(appServicePlanName) ? appServicePlanName : '${abbrs.webServerFarms}backend-${resourceToken}'
     appServiceName: appServiceName
     storageAccountName: storage.outputs.name


### PR DESCRIPTION
This pull request primarily includes changes to the `infra` files in the application, specifically to the `backend.bicep`, `appservice.bicep`, `appserviceplan.bicep`, `functions.bicep`, and `main.bicep` files. The changes are focused on the removal of specific runtime properties and parameters, and the modification of tags in the `backend` module. 

Removal of specific runtime properties:

* [`infra/core/host/appservice.bicep`](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedL11-R12): Removed `runtimeName`, `runtimeVersion`, and `runtimeNameAndVersion` parameters, and `linuxFxVersion` from the `appService` resource and parameters. [[1]](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedL11-R12) [[2]](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedL34) [[3]](diffhunk://#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedL50)
* [`infra/core/host/functions.bicep`](diffhunk://#diff-fdfa3d588bb37778e24108dda63c3cf8e68d29ed74974ceecd88c1b019014241L38): Removed `linuxFxVersion`, `runtimeName`, `runtimeVersion`, and `runtimeNameAndVersion` from the `functions` module. [[1]](diffhunk://#diff-fdfa3d588bb37778e24108dda63c3cf8e68d29ed74974ceecd88c1b019014241L38) [[2]](diffhunk://#diff-fdfa3d588bb37778e24108dda63c3cf8e68d29ed74974ceecd88c1b019014241L66-L71)

Removal of `kind` and `reserved` properties:

* [`infra/app/backend.bicep`](diffhunk://#diff-7d811948fcd2820e60d5618ba1f7262bdf20b65b0971267913211a10b94de686L27): Removed `kind` property from the `appServicePlan` module.
* [`infra/core/host/appserviceplan.bicep`](diffhunk://#diff-f53c6fec31f9555c6579e3f9345b8335e370be7d2d30cd092c1ca1524da4082aL6): Removed `reserved` parameter and property from the `appServicePlan` resource. [[1]](diffhunk://#diff-f53c6fec31f9555c6579e3f9345b8335e370be7d2d30cd092c1ca1524da4082aL6) [[2]](diffhunk://#diff-f53c6fec31f9555c6579e3f9345b8335e370be7d2d30cd092c1ca1524da4082aL15-L17)

Modification of tags:

* [`infra/app/backend.bicep`](diffhunk://#diff-7d811948fcd2820e60d5618ba1f7262bdf20b65b0971267913211a10b94de686L38-L39): Removed the union operation for `tags` in the `backend` module.
* [`infra/main.bicep`](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4L158-R158): Removed the union operation for `tags` in the `backend` module.